### PR TITLE
Add task generator and tests

### DIFF
--- a/convert.js
+++ b/convert.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+
+function generate() {
+  const data = fs.readFileSync('tasks.json', 'utf8');
+  const tasks = JSON.parse(data);
+  let md = '| id | title |\n| --- | ----- |\n';
+  for (const task of tasks) {
+    md += `| ${task.id} | ${task.title} |\n`;
+  }
+  fs.writeFileSync('tasks.md', md);
+}
+
+if (require.main === module) {
+  generate();
+}
+
+module.exports = generate;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "codex-demo",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "scripts": {
+    "generate": "node convert.js",
+    "test": "node tests/convert.test.py"
+  },
+  "devDependencies": {
+    "vitest": "*"
+  }
+}

--- a/tasks.json
+++ b/tasks.json
@@ -1,0 +1,1 @@
+[{"id": 1, "title": "Buy bitcoin"}]

--- a/tasks.md
+++ b/tasks.md
@@ -1,0 +1,3 @@
+| id | title |
+| --- | ----- |
+| 1 | Buy bitcoin |

--- a/tests/convert.test.py
+++ b/tests/convert.test.py
@@ -1,0 +1,11 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const assert = require('assert');
+
+if (fs.existsSync('tasks.md')) fs.unlinkSync('tasks.md');
+execSync('pnpm run generate', { stdio: 'inherit' });
+assert.ok(fs.existsSync('tasks.md'), 'tasks.md not generated');
+const content = fs.readFileSync('tasks.md', 'utf8');
+assert.ok(content.includes('Buy bitcoin'), 'Buy bitcoin missing');
+console.log('All tests passed.');
+


### PR DESCRIPTION
## Summary
- create `tasks.json` with initial task
- convert `tasks.json` into Markdown table via `convert.js`
- track generated `tasks.md`
- add placeholder dev dependency for vitest
- implement test script `tests/convert.test.py`
- update npm scripts for generating and testing

## Testing
- `pnpm test`